### PR TITLE
Default include also for Zabbix Proxy

### DIFF
--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -47,7 +47,8 @@
       'config': '/etc/zabbix/zabbix_proxy.conf',
       'dbname': '/var/lib/zabbix/zabbix_proxy.db',
       'pidfile': '/var/run/zabbix/zabbix_proxy.pid',
-      'logfile': '/var/log/zabbix/zabbix_proxy.log'
+      'logfile': '/var/log/zabbix/zabbix_proxy.log',
+      'includes': ['/etc/zabbix/zabbix_proxy.d/']
     },
     'mysql': {
       'pkgs': ['python-mysqldb']


### PR DESCRIPTION
In my humble opinion the Zabbix Proxy should also have a default include, like the Zabbix Agent and literally every other service we normally install and use on Debian. 
There is also an open feature request for this at Zabbix: https://support.zabbix.com/browse/ZBXNEXT-4641